### PR TITLE
feat: handle gamepad controllers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Keyboard Fallback
+# Enable keyboard fallback for both players
+# When enabled, Player 1 uses WASD/ZQSD keys, Player 2 uses arrow keys
+# When disabled, game pauses when any gamepad unplugs
+NUXT_PUBLIC_KEYBOARD_FALLBACK_ENABLED=true

--- a/game/Stage.machine.ts
+++ b/game/Stage.machine.ts
@@ -17,7 +17,9 @@ export const stageMachine = setup({
       | { type: 'save'; name: string }
       | { type: 'pause' }
       | { type: 'resume' }
-      | { type: 'leaderboard' },
+      | { type: 'leaderboard' }
+      | { type: 'controllersReady' }
+      | { type: 'controllerDisconnected' },
   },
   actions: {
     hideLoadingOverlay: () => {},
@@ -85,10 +87,22 @@ export const stageMachine = setup({
           target: 'Menu',
         },
         play: {
-          target: 'Level',
+          target: 'WaitingForControllers',
         },
       },
       description: 'Display the commands',
+    },
+
+    WaitingForControllers: {
+      on: {
+        controllersReady: {
+          target: 'Level',
+        },
+        back: {
+          target: 'Tutorial',
+        },
+      },
+      description: 'Wait for 2 controllers to be connected',
     },
 
     Leaderboard: {
@@ -106,6 +120,9 @@ export const stageMachine = setup({
         },
         end: {
           target: 'Score',
+        },
+        controllerDisconnected: {
+          target: 'Pause',
         },
       },
     },

--- a/game/Stage.ts
+++ b/game/Stage.ts
@@ -26,6 +26,7 @@ import { Time } from './utils/Time';
 export class Stage {
   #actor: Actor<AnyActorLogic>;
   #scene: Scene;
+  #camera: Camera;
   #resources: Resources;
   #time: Time;
   #environment: Environment | null = null;
@@ -38,14 +39,14 @@ export class Stage {
     new Debug();
 
     this.#scene = new Scene();
-    const camera = new Camera(this.#scene, canvas);
-    const renderer = new Renderer(this.#scene, canvas, camera);
+    this.#camera = new Camera(this.#scene, canvas);
+    const renderer = new Renderer(this.#scene, canvas, this.#camera);
     const loadingOverlay = new LoadingOverlay(this.#scene);
 
     const sizes = new Sizes();
     sizes.addEventListener('resize', () => {
       window.requestAnimationFrame(() => {
-        camera.setSizesAndRatio();
+        this.#camera.setSizesAndRatio();
 
         /**
          * Must be called after the camera has been resized,
@@ -136,7 +137,7 @@ export class Stage {
 
     this.#time = new Time();
     this.#time.addEventListener('tick', () => {
-      camera.update();
+      this.#camera.update();
       loadingOverlay.update();
       renderer.update();
     });
@@ -182,7 +183,7 @@ export class Stage {
     }
 
     const startScreen = new StartScreen(this.#actor, this.#scene);
-    const levelScreen = new LevelScreen(this.#actor, this.#scene);
+    const levelScreen = new LevelScreen(this.#actor, this.#scene, this.#camera);
     const menuScreen = new MenuScreen(this.#actor, this.#scene);
     const tutorialScreen = new TutorialScreen(this.#actor, this.#scene);
     const waitingScreen = new WaitingScreen(this.#actor, this.#scene);

--- a/game/Stage.ts
+++ b/game/Stage.ts
@@ -15,6 +15,7 @@ import { SavingScoreScreen } from './screens/SavingScoreScreen';
 import { ScoreScreen } from './screens/ScoreScreen';
 import { StartScreen } from './screens/StartScreen';
 import { TutorialScreen } from './screens/TutorialScreen';
+import { WaitingScreen } from './screens/WaitingScreen';
 import { stageMachine } from './Stage.machine';
 import { Debug } from './utils/Debug';
 import { Renderer } from './utils/Renderer';
@@ -184,6 +185,7 @@ export class Stage {
     const levelScreen = new LevelScreen(this.#actor, this.#scene);
     const menuScreen = new MenuScreen(this.#actor, this.#scene);
     const tutorialScreen = new TutorialScreen(this.#actor, this.#scene);
+    const waitingScreen = new WaitingScreen(this.#actor, this.#scene);
     const leaderboardScreen = new LeaderboardScreen(this.#actor, this.#scene);
     const pauseScreen = new PauseScreen(this.#actor, this.#scene);
     const scoreScreen = new ScoreScreen(this.#actor, this.#scene);
@@ -201,6 +203,7 @@ export class Stage {
       levelScreen.update();
       menuScreen.update();
       tutorialScreen.update();
+      waitingScreen.update();
       leaderboardScreen.update();
       pauseScreen.update();
       scoreScreen.update();

--- a/game/Stage.ts
+++ b/game/Stage.ts
@@ -1,7 +1,7 @@
 import { Scene } from 'three';
 import { type Actor, type AnyActorLogic, createActor, fromPromise } from 'xstate';
 
-import { navigateTo } from '#app';
+import { navigateTo, useRuntimeConfig } from '#app';
 
 import { Camera } from './Camera';
 import { Environment } from './Environment';
@@ -18,6 +18,7 @@ import { TutorialScreen } from './screens/TutorialScreen';
 import { WaitingScreen } from './screens/WaitingScreen';
 import { stageMachine } from './Stage.machine';
 import { Debug } from './utils/Debug';
+import { GamepadManager } from './utils/input/GamepadManager';
 import { Renderer } from './utils/Renderer';
 import { Resources } from './utils/Resources';
 import { Sizes } from './utils/Sizes';
@@ -101,6 +102,15 @@ export class Stage {
       //   path: '/game/svg/bmLogo.svg',
       // },
     });
+
+    // Initialize keyboard fallback based on runtime config
+    const config = useRuntimeConfig();
+    const gamepadManager = GamepadManager.getInstance();
+    if (config.public.keyboardFallbackEnabled) {
+      gamepadManager.enableKeyboards();
+    } else {
+      gamepadManager.disableKeyboards();
+    }
 
     this.#actor = createActor(
       stageMachine.provide({

--- a/game/hud/ControllersHUD.ts
+++ b/game/hud/ControllersHUD.ts
@@ -125,7 +125,7 @@ export class ControllersHUD {
 
     const getControllerInfo = (source: any) => {
       if (!source) return { type: 'None', status: '' };
-      const type = source.constructor.name === 'InputController' ? 'Keyboard' : 'Gamepad';
+      const type = source.constructor.name === 'KeyboardController' ? 'Keyboard' : 'Gamepad';
       const status = source.connected ? '' : ' (disconnected)';
       return { type, status };
     };

--- a/game/hud/ControllersHUD.ts
+++ b/game/hud/ControllersHUD.ts
@@ -1,0 +1,177 @@
+import { Group, type Mesh, MeshStandardMaterial, type PerspectiveCamera } from 'three';
+
+import { createTextMesh } from '../lib/createTextMesh';
+import { Resources } from '../utils/Resources';
+import type { GamepadManager } from '../utils/input/GamepadManager';
+
+export class ControllersHUD {
+  static readonly HUD_DISTANCE = 5;
+  static readonly HUD_PADDING = 0.15;
+  static readonly HUD_LINE_HEIGHT = 0.06;
+
+  #camera: PerspectiveCamera;
+  #resources: Resources;
+  #gamepadManager: GamepadManager;
+
+  #group: Group;
+  #player1Mesh: Mesh | null = null;
+  #player2Mesh: Mesh | null = null;
+  #material: MeshStandardMaterial;
+
+  constructor(camera: PerspectiveCamera, gamepadManager: GamepadManager) {
+    this.#camera = camera;
+    this.#resources = Resources.getInstance();
+    this.#gamepadManager = gamepadManager;
+
+    this.#group = new Group();
+    this.#camera.add(this.#group);
+
+    this.#material = new MeshStandardMaterial({
+      color: '#FFFFFF',
+      metalness: 0.2,
+      roughness: 0.6,
+    });
+
+    this.createText();
+    this.setupListeners();
+  }
+
+  private setupListeners() {
+    this.#gamepadManager.addEventListener('gamepadAssigned', () => {
+      this.updateText();
+    });
+
+    this.#gamepadManager.addEventListener('gamepadDisconnected', () => {
+      this.updateText();
+    });
+
+    this.#gamepadManager.addEventListener('controllersReadyChange', () => {
+      this.updateText();
+    });
+  }
+
+  #calculateFrustumBounds() {
+    const distance = ControllersHUD.HUD_DISTANCE;
+    const vFov = (this.#camera.fov * Math.PI) / 180;
+    const visibleHeight = 2 * Math.tan(vFov / 2) * distance;
+    const visibleWidth = visibleHeight * this.#camera.aspect;
+
+    return {
+      top: visibleHeight / 2,
+      left: -visibleWidth / 2,
+    };
+  }
+
+  #updateMeshPositions() {
+    const bounds = this.#calculateFrustumBounds();
+    const padding = ControllersHUD.HUD_PADDING;
+    const lineHeight = ControllersHUD.HUD_LINE_HEIGHT;
+
+    if (this.#player1Mesh) {
+      this.#player1Mesh.position.set(
+        bounds.left + padding,
+        bounds.top - padding,
+        -ControllersHUD.HUD_DISTANCE
+      );
+    }
+
+    if (this.#player2Mesh) {
+      this.#player2Mesh.position.set(
+        bounds.left + padding,
+        bounds.top - padding - lineHeight,
+        -ControllersHUD.HUD_DISTANCE
+      );
+    }
+  }
+
+  private #alignTextLeft(mesh: Mesh) {
+    mesh.geometry.computeBoundingBox();
+    if (mesh.geometry.boundingBox) {
+      const width = mesh.geometry.boundingBox.max.x - mesh.geometry.boundingBox.min.x;
+      mesh.geometry.translate(width / 2, 0, 0);
+    }
+  }
+
+  private createText() {
+    const font = this.#resources.getFontAsset('interFont');
+    if (!font) return;
+
+    this.#player1Mesh = createTextMesh('', font, {
+      extrusionDepth: 0.005,
+      size: 0.0375,
+      material: this.#material,
+    });
+    this.#alignTextLeft(this.#player1Mesh);
+    this.#group.add(this.#player1Mesh);
+
+    this.#player2Mesh = createTextMesh('', font, {
+      extrusionDepth: 0.005,
+      size: 0.0375,
+      material: this.#material,
+    });
+    this.#alignTextLeft(this.#player2Mesh);
+    this.#group.add(this.#player2Mesh);
+
+    this.#updateMeshPositions();
+    this.updateText();
+  }
+
+  private updateText() {
+    const font = this.#resources.getFontAsset('interFont');
+    if (!font) return;
+
+    const p1Source = this.#gamepadManager.getInputSource(1);
+    const p2Source = this.#gamepadManager.getInputSource(2);
+
+    const getControllerInfo = (source: any) => {
+      if (!source) return { type: 'None', status: '' };
+      const type = source.constructor.name === 'InputController' ? 'Keyboard' : 'Gamepad';
+      const status = source.connected ? '' : ' (disconnected)';
+      return { type, status };
+    };
+
+    const p1Info = getControllerInfo(p1Source);
+    const p2Info = getControllerInfo(p2Source);
+
+    if (this.#player1Mesh) {
+      this.#group.remove(this.#player1Mesh);
+      this.#player1Mesh = createTextMesh(`P1: ${p1Info.type}${p1Info.status}`, font, {
+        extrusionDepth: 0.005,
+        size: 0.0375,
+        material: this.#material,
+      });
+      this.#alignTextLeft(this.#player1Mesh);
+      this.#group.add(this.#player1Mesh);
+    }
+
+    if (this.#player2Mesh) {
+      this.#group.remove(this.#player2Mesh);
+      this.#player2Mesh = createTextMesh(`P2: ${p2Info.type}${p2Info.status}`, font, {
+        extrusionDepth: 0.005,
+        size: 0.0375,
+        material: this.#material,
+      });
+      this.#alignTextLeft(this.#player2Mesh);
+      this.#group.add(this.#player2Mesh);
+    }
+
+    this.#updateMeshPositions();
+  }
+
+  public show() {
+    this.#group.visible = true;
+    this.updateText();
+  }
+
+  public hide() {
+    this.#group.visible = false;
+  }
+
+  public update() {
+    // No animation needed for now
+  }
+
+  public updatePosition() {
+    this.#updateMeshPositions();
+  }
+}

--- a/game/screens/LevelScreen.ts
+++ b/game/screens/LevelScreen.ts
@@ -1,6 +1,8 @@
 import { Group, type Scene } from 'three';
 import type { Actor, AnyActorLogic } from 'xstate';
 
+import { useRuntimeConfig } from '#app';
+
 import type { Camera } from '../Camera';
 import { ControllersHUD } from '../hud/ControllersHUD';
 import { GamepadManager } from '../utils/input/GamepadManager';
@@ -39,7 +41,10 @@ export class LevelScreen {
     });
 
     this.#gamepadManager.addEventListener('gamepadDisconnected', () => {
-      if (this.#group.visible) {
+      if (!this.#group.visible) return;
+
+      const config = useRuntimeConfig();
+      if (!config.public.keyboardFallbackEnabled) {
         this.#stageActor.send({ type: 'controllerDisconnected' });
       }
     });

--- a/game/screens/LevelScreen.ts
+++ b/game/screens/LevelScreen.ts
@@ -1,14 +1,18 @@
 import { Group, type Scene } from 'three';
 import type { Actor, AnyActorLogic } from 'xstate';
 
+import type { Camera } from '../Camera';
+import { ControllersHUD } from '../hud/ControllersHUD';
 import { GamepadManager } from '../utils/input/GamepadManager';
 import { Physics } from '../utils/Physics';
+import { Sizes } from '../utils/Sizes';
 import { Level } from '../world/Level';
 import { Player } from '../world/Player';
 
 export class LevelScreen {
   #stageActor: Actor<AnyActorLogic>;
   #scene: Scene;
+  #camera: Camera;
   #physics: Physics;
   #gamepadManager: GamepadManager;
 
@@ -16,11 +20,13 @@ export class LevelScreen {
   #player1: Player | null = null;
   #player2: Player | null = null;
   #level: Level | null = null;
+  #hud: ControllersHUD;
   #physicsInitialized = false;
 
-  constructor(stageActor: Actor<AnyActorLogic>, scene: Scene) {
+  constructor(stageActor: Actor<AnyActorLogic>, scene: Scene, camera: Camera) {
     this.#stageActor = stageActor;
     this.#scene = scene;
+    this.#camera = camera;
     this.#physics = Physics.getInstance();
     this.#gamepadManager = GamepadManager.getInstance();
 
@@ -49,6 +55,13 @@ export class LevelScreen {
 
     this.#group = new Group();
     this.#scene.add(this.#group);
+
+    this.#hud = new ControllersHUD(this.#camera.camera, this.#gamepadManager);
+
+    const sizes = Sizes.getInstance();
+    sizes.addEventListener('resize', () => {
+      this.#hud.updatePosition();
+    });
   }
 
   #levelInitialized = false;
@@ -68,11 +81,13 @@ export class LevelScreen {
 
   private show() {
     this.#group.visible = true;
+    this.#hud.show();
     this.initLevel();
   }
 
   private hide() {
     this.#group.visible = false;
+    this.#hud.hide();
   }
 
   public update() {
@@ -84,5 +99,6 @@ export class LevelScreen {
     this.#player1?.update();
     this.#player2?.update();
     this.#level?.update();
+    this.#hud.update();
   }
 }

--- a/game/screens/LevelScreen.ts
+++ b/game/screens/LevelScreen.ts
@@ -38,6 +38,15 @@ export class LevelScreen {
       }
     });
 
+    this.#gamepadManager.addEventListener('controllersReadyChange', ((event: CustomEvent) => {
+      const { ready } = event.detail;
+      const currentState = this.#stageActor.getSnapshot();
+
+      if (ready && currentState.matches('Pause')) {
+        this.#stageActor.send({ type: 'resume' });
+      }
+    }) as EventListener);
+
     this.#group = new Group();
     this.#scene.add(this.#group);
   }

--- a/game/screens/StartScreen.ts
+++ b/game/screens/StartScreen.ts
@@ -68,7 +68,7 @@ export class StartScreen {
   }
 
   private show() {
-    this.#inputController.onKeyUp(() => this.onKeyUp());
+    this.#inputController.onButtonUp(() => this.onButtonUp());
     this.#group.visible = true;
   }
 
@@ -77,7 +77,7 @@ export class StartScreen {
     this.#group.visible = false;
   }
 
-  private onKeyUp() {
+  private onButtonUp() {
     this.#stageActor.send({ type: 'start' });
   }
 

--- a/game/screens/StartScreen.ts
+++ b/game/screens/StartScreen.ts
@@ -2,14 +2,14 @@ import { Group, type Mesh, MeshStandardMaterial, type Scene } from 'three';
 import type { Actor, AnyActorLogic } from 'xstate';
 
 import { createTextMesh } from '../lib/createTextMesh';
-import { InputController } from '../utils/InputController';
+import { KeyboardController } from '../utils/input/KeyboardController';
 import { Resources } from '../utils/Resources';
 
 export class StartScreen {
   #stageActor: Actor<AnyActorLogic>;
   #scene: Scene;
   #resources: Resources;
-  #inputController: InputController;
+  #inputController: KeyboardController;
 
   #group: Group;
   #titleMesh: Mesh | null = null;
@@ -20,7 +20,7 @@ export class StartScreen {
     this.#stageActor = stageActor;
     this.#scene = scene;
     this.#resources = Resources.getInstance();
-    this.#inputController = new InputController();
+    this.#inputController = new KeyboardController();
 
     this.#group = new Group();
     this.#group.position.set(0, 30, 0);

--- a/game/screens/WaitingScreen.ts
+++ b/game/screens/WaitingScreen.ts
@@ -1,0 +1,156 @@
+import { Group, type Mesh, MeshStandardMaterial, type Scene } from 'three';
+import type { Actor, AnyActorLogic } from 'xstate';
+
+import { createTextMesh } from '../lib/createTextMesh';
+import { GamepadManager } from '../utils/input/GamepadManager';
+import { Resources } from '../utils/Resources';
+
+export class WaitingScreen {
+  #stageActor: Actor<AnyActorLogic>;
+  #scene: Scene;
+  #resources: Resources;
+  #gamepadManager: GamepadManager;
+
+  #group: Group;
+  #titleMesh: Mesh | null = null;
+  #player1Mesh: Mesh | null = null;
+  #player2Mesh: Mesh | null = null;
+  #backMesh: Mesh | null = null;
+  #material: MeshStandardMaterial;
+  #connectedMaterial: MeshStandardMaterial;
+
+  constructor(stageActor: Actor<AnyActorLogic>, scene: Scene) {
+    this.#stageActor = stageActor;
+    this.#scene = scene;
+    this.#resources = Resources.getInstance();
+    this.#gamepadManager = GamepadManager.getInstance();
+
+    this.#group = new Group();
+    this.#group.position.set(0, 30, 0);
+    this.#scene.add(this.#group);
+
+    this.#stageActor.subscribe((state) => {
+      if (state.matches('WaitingForControllers')) {
+        this.show();
+      } else {
+        this.hide();
+      }
+    });
+
+    this.#material = new MeshStandardMaterial({
+      color: '#FBD954',
+      metalness: 0.3,
+      roughness: 0.4,
+    });
+
+    this.#connectedMaterial = new MeshStandardMaterial({
+      color: '#54FB7D',
+      metalness: 0.3,
+      roughness: 0.4,
+    });
+
+    this.#gamepadManager.addEventListener('controllersReadyChange', () => {
+      this.updateStatus();
+      if (this.#gamepadManager.areControllersReady()) {
+        this.#stageActor.send({ type: 'controllersReady' });
+      }
+    });
+
+    this.#gamepadManager.addEventListener('gamepadAssigned', () => this.updateStatus());
+    this.#gamepadManager.addEventListener('gamepadReconnected', () => this.updateStatus());
+    this.#gamepadManager.addEventListener('gamepadDisconnected', () => this.updateStatus());
+
+    this.createText();
+  }
+
+  private createText() {
+    const font = this.#resources.getFontAsset('interFont');
+
+    if (!font) {
+      return;
+    }
+
+    this.#titleMesh = createTextMesh('Connect Controllers', font, {
+      extrusionDepth: 0.1,
+      size: 1.2,
+      material: this.#material,
+    });
+    this.#titleMesh.position.set(0, 4, 0);
+    this.#group.add(this.#titleMesh);
+
+    this.#player1Mesh = createTextMesh('Player 1: Waiting...', font, {
+      extrusionDepth: 0.05,
+      size: 0.7,
+      material: this.#material,
+    });
+    this.#player1Mesh.position.set(0, 1.5, 0);
+    this.#group.add(this.#player1Mesh);
+
+    this.#player2Mesh = createTextMesh('Player 2: Waiting...', font, {
+      extrusionDepth: 0.05,
+      size: 0.7,
+      material: this.#material,
+    });
+    this.#player2Mesh.position.set(0, 0, 0);
+    this.#group.add(this.#player2Mesh);
+
+    this.#backMesh = createTextMesh('Back', font, {
+      extrusionDepth: 0.05,
+      size: 0.8,
+      material: this.#material,
+    });
+    this.#backMesh.position.set(0, -2, 0);
+    this.#group.add(this.#backMesh);
+
+    this.updateStatus();
+  }
+
+  private updateStatus() {
+    const status = this.#gamepadManager.getConnectionStatus();
+    this.updatePlayerMesh(this.#player1Mesh, 1, status.player1);
+    this.updatePlayerMesh(this.#player2Mesh, 2, status.player2);
+  }
+
+  private updatePlayerMesh(mesh: Mesh | null, playerId: number, connected: boolean) {
+    if (!mesh) return;
+
+    const font = this.#resources.getFontAsset('interFont');
+    if (!font) return;
+
+    const text = connected ? `Player ${playerId}: Connected` : `Player ${playerId}: Waiting...`;
+    const material = connected ? this.#connectedMaterial : this.#material;
+
+    this.#group.remove(mesh);
+
+    const newMesh = createTextMesh(text, font, {
+      extrusionDepth: 0.05,
+      size: 0.7,
+      material,
+    });
+    newMesh.position.copy(mesh.position);
+    this.#group.add(newMesh);
+
+    if (playerId === 1) {
+      this.#player1Mesh = newMesh;
+    } else {
+      this.#player2Mesh = newMesh;
+    }
+  }
+
+  private show() {
+    this.#group.visible = true;
+    this.updateStatus();
+
+    if (this.#gamepadManager.areControllersReady()) {
+      this.#stageActor.send({ type: 'controllersReady' });
+    }
+  }
+
+  private hide() {
+    this.#group.visible = false;
+  }
+
+  public update() {
+    if (!this.#group.visible) return;
+  }
+}

--- a/game/utils/InputController.ts
+++ b/game/utils/InputController.ts
@@ -1,9 +1,13 @@
-export class InputController {
-  #keyUpCallback: ((event: KeyboardEvent) => void) | null = null;
+import type { InputSource, InputVector } from './input/InputSource';
+
+export class InputController implements InputSource {
+  #buttonUpCallback: ((button: string) => void) | null = null;
   #boundKeyUpHandler: (event: KeyboardEvent) => void;
   #boundKeyDownHandler: (event: KeyboardEvent) => void;
 
   #keysPressed = new Set<string>();
+
+  readonly connected = true;
 
   constructor() {
     if (!window) {
@@ -17,26 +21,53 @@ export class InputController {
     window.addEventListener('keydown', this.#boundKeyDownHandler);
   }
 
-  public onKeyUp(callback: (event: KeyboardEvent) => void) {
-    this.#keyUpCallback = callback;
+  public onButtonUp(callback: (button: string) => void) {
+    this.#buttonUpCallback = callback;
   }
 
-  public isKeyPressed(key: string): boolean {
-    return this.#keysPressed.has(key);
+  public isButtonPressed(button: string): boolean {
+    return this.#keysPressed.has(button);
+  }
+
+  public getMovement(): InputVector {
+    let x = 0;
+    let z = 0;
+
+    if (
+      this.#keysPressed.has('ArrowLeft') ||
+      this.#keysPressed.has('KeyA') ||
+      this.#keysPressed.has('KeyQ')
+    ) {
+      x = -1;
+    } else if (this.#keysPressed.has('ArrowRight') || this.#keysPressed.has('KeyD')) {
+      x = 1;
+    }
+
+    if (
+      this.#keysPressed.has('ArrowUp') ||
+      this.#keysPressed.has('KeyW') ||
+      this.#keysPressed.has('KeyZ')
+    ) {
+      z = -1;
+    } else if (this.#keysPressed.has('ArrowDown') || this.#keysPressed.has('KeyS')) {
+      z = 1;
+    }
+
+    return { x, z };
   }
 
   public cleanup() {
     window.removeEventListener('keyup', this.#boundKeyUpHandler);
     window.removeEventListener('keydown', this.#boundKeyDownHandler);
-    this.#keyUpCallback = null;
+    this.#buttonUpCallback = null;
     this.#keysPressed.clear();
   }
 
   #handleKeyUp(event: KeyboardEvent) {
     this.#keysPressed.delete(event.code);
 
-    if (this.#keyUpCallback) {
-      this.#keyUpCallback(event);
+    if (this.#buttonUpCallback) {
+      this.#buttonUpCallback(event.code);
     }
   }
 

--- a/game/utils/input/GamepadController.ts
+++ b/game/utils/input/GamepadController.ts
@@ -25,6 +25,10 @@ export class GamepadController implements InputSource {
     this.#gamepadIndex = newIndex;
   }
 
+  getGamepadIndex(): number {
+    return this.#gamepadIndex;
+  }
+
   getMovement(): InputVector {
     const gamepad = navigator.getGamepads()[this.#gamepadIndex];
     if (!gamepad) return { x: 0, z: 0 };

--- a/game/utils/input/GamepadController.ts
+++ b/game/utils/input/GamepadController.ts
@@ -1,0 +1,76 @@
+import type { InputSource, InputVector } from './InputSource';
+import type { ControllerProfile } from './profiles';
+
+export class GamepadController implements InputSource {
+  #gamepadIndex: number;
+  #profile: ControllerProfile;
+  #buttonUpCallback: ((button: string) => void) | null = null;
+  #previousButtonStates: boolean[] = [];
+  #connected = true;
+
+  constructor(gamepadIndex: number, profile: ControllerProfile) {
+    this.#gamepadIndex = gamepadIndex;
+    this.#profile = profile;
+  }
+
+  get connected(): boolean {
+    return this.#connected && navigator.getGamepads()[this.#gamepadIndex] !== null;
+  }
+
+  setConnected(value: boolean): void {
+    this.#connected = value;
+  }
+
+  updateIndex(newIndex: number): void {
+    this.#gamepadIndex = newIndex;
+  }
+
+  getMovement(): InputVector {
+    const gamepad = navigator.getGamepads()[this.#gamepadIndex];
+    if (!gamepad) return { x: 0, z: 0 };
+
+    let x = gamepad.axes[this.#profile.leftStickX] ?? 0;
+    let z = gamepad.axes[this.#profile.leftStickY] ?? 0;
+
+    if (Math.abs(x) < this.#profile.deadzone) x = 0;
+    if (Math.abs(z) < this.#profile.deadzone) z = 0;
+
+    return { x, z };
+  }
+
+  isButtonPressed(button: string): boolean {
+    const gamepad = navigator.getGamepads()[this.#gamepadIndex];
+    if (!gamepad) return false;
+
+    const buttons = this.#profile.buttons as Record<string, number>;
+    const buttonIndex = buttons[button];
+    if (buttonIndex === undefined) return false;
+
+    return gamepad.buttons[buttonIndex]?.pressed ?? false;
+  }
+
+  pollButtons(): void {
+    const gamepad = navigator.getGamepads()[this.#gamepadIndex];
+    if (!gamepad) return;
+
+    for (const [name, index] of Object.entries(this.#profile.buttons)) {
+      const wasPressed = this.#previousButtonStates[index] ?? false;
+      const isPressed = gamepad.buttons[index]?.pressed ?? false;
+
+      if (wasPressed && !isPressed && this.#buttonUpCallback) {
+        this.#buttonUpCallback(name);
+      }
+
+      this.#previousButtonStates[index] = isPressed;
+    }
+  }
+
+  onButtonUp(callback: (button: string) => void): void {
+    this.#buttonUpCallback = callback;
+  }
+
+  cleanup(): void {
+    this.#buttonUpCallback = null;
+    this.#previousButtonStates = [];
+  }
+}

--- a/game/utils/input/GamepadManager.ts
+++ b/game/utils/input/GamepadManager.ts
@@ -1,0 +1,227 @@
+import { InputController } from '../InputController';
+import { GamepadController } from './GamepadController';
+import type { InputSource } from './InputSource';
+import {
+  type ControllerProfile,
+  LogitechProfile,
+  PS4Profile,
+  XboxProfile,
+} from './profiles';
+
+export type PlayerId = 1 | 2;
+
+interface PlayerAssignment {
+  playerId: PlayerId;
+  gamepadId: string;
+  controller: GamepadController;
+}
+
+export class GamepadManager extends EventTarget {
+  static #instance: GamepadManager | null = null;
+
+  #profiles: ControllerProfile[] = [LogitechProfile, XboxProfile, PS4Profile];
+  #assignments = new Map<PlayerId, PlayerAssignment>();
+  #keyboardFallback: InputController | null = null;
+  #knownGamepadIds = new Map<string, PlayerId>();
+
+  private constructor() {
+    super();
+    this.#setupEventListeners();
+    this.#scanConnectedGamepads();
+
+    // Poll for gamepads - browser requires button press before gamepad is visible
+    this.#pollInterval = window.setInterval(() => this.#scanConnectedGamepads(), 500);
+
+    // Enable keyboard as fallback for player 1
+    this.enableKeyboardFallback();
+  }
+
+  #pollInterval: number | null = null;
+
+  static getInstance(): GamepadManager {
+    if (!GamepadManager.#instance) {
+      GamepadManager.#instance = new GamepadManager();
+    }
+    return GamepadManager.#instance;
+  }
+
+  #setupEventListeners(): void {
+    window.addEventListener('gamepadconnected', (e) => this.#onGamepadConnected(e));
+    window.addEventListener('gamepaddisconnected', (e) => this.#onGamepadDisconnected(e));
+  }
+
+  #scanConnectedGamepads(): void {
+    const gamepads = navigator.getGamepads();
+    for (const gamepad of gamepads) {
+      if (gamepad) {
+        const gamepadId = this.#generateGamepadId(gamepad);
+        // Skip if already assigned
+        const existingPlayerId = this.#knownGamepadIds.get(gamepadId);
+        if (existingPlayerId !== undefined) {
+          const assignment = this.#assignments.get(existingPlayerId);
+          if (assignment?.controller.connected) continue;
+        }
+        this.#assignGamepad(gamepad);
+      }
+    }
+  }
+
+  #detectProfile(gamepad: Gamepad): ControllerProfile {
+    for (const profile of this.#profiles) {
+      if (profile.matchPatterns.some((p) => p.test(gamepad.id))) {
+        return profile;
+      }
+    }
+    return LogitechProfile;
+  }
+
+  #generateGamepadId(gamepad: Gamepad): string {
+    return gamepad.id;
+  }
+
+  #assignGamepad(gamepad: Gamepad): void {
+    const gamepadId = this.#generateGamepadId(gamepad);
+    const profile = this.#detectProfile(gamepad);
+    const previousPlayerId = this.#knownGamepadIds.get(gamepadId);
+
+    if (previousPlayerId !== undefined) {
+      const existing = this.#assignments.get(previousPlayerId);
+      if (existing) {
+        existing.controller.setConnected(true);
+        existing.controller.updateIndex(gamepad.index);
+        this.dispatchEvent(
+          new CustomEvent('gamepadReconnected', {
+            detail: { playerId: previousPlayerId, gamepad },
+          }),
+        );
+      } else {
+        const controller = new GamepadController(gamepad.index, profile);
+        this.#assignments.set(previousPlayerId, {
+          playerId: previousPlayerId,
+          gamepadId,
+          controller,
+        });
+        this.dispatchEvent(
+          new CustomEvent('gamepadReconnected', {
+            detail: { playerId: previousPlayerId, gamepad },
+          }),
+        );
+      }
+    } else {
+      const availableSlot = this.#getFirstAvailableSlot();
+      if (availableSlot) {
+        const controller = new GamepadController(gamepad.index, profile);
+        this.#assignments.set(availableSlot, {
+          playerId: availableSlot,
+          gamepadId,
+          controller,
+        });
+        this.#knownGamepadIds.set(gamepadId, availableSlot);
+        this.dispatchEvent(
+          new CustomEvent('gamepadAssigned', {
+            detail: { playerId: availableSlot, gamepad },
+          }),
+        );
+      }
+    }
+
+    this.#checkControllersReady();
+  }
+
+  #onGamepadConnected(event: GamepadEvent): void {
+    this.#assignGamepad(event.gamepad);
+  }
+
+  #onGamepadDisconnected(event: GamepadEvent): void {
+    const gamepad = event.gamepad;
+    const gamepadId = this.#generateGamepadId(gamepad);
+
+    for (const [playerId, assignment] of this.#assignments) {
+      if (assignment.gamepadId === gamepadId) {
+        assignment.controller.setConnected(false);
+        this.dispatchEvent(
+          new CustomEvent('gamepadDisconnected', {
+            detail: { playerId, gamepad },
+          }),
+        );
+        break;
+      }
+    }
+
+    this.#checkControllersReady();
+  }
+
+  #getFirstAvailableSlot(): PlayerId | null {
+    // If keyboard fallback is enabled, reserve slot 1 for keyboard, assign gamepads to slot 2 first
+    if (this.#keyboardFallback) {
+      if (!this.#assignments.has(2)) return 2;
+      if (!this.#assignments.has(1)) return 1;
+    } else {
+      if (!this.#assignments.has(1)) return 1;
+      if (!this.#assignments.has(2)) return 2;
+    }
+    return null;
+  }
+
+  #checkControllersReady(): void {
+    const ready = this.areControllersReady();
+    this.dispatchEvent(new CustomEvent('controllersReadyChange', { detail: { ready } }));
+  }
+
+  areControllersReady(): boolean {
+    const p1 = this.getInputSource(1);
+    const p2 = this.getInputSource(2);
+    return (p1?.connected ?? false) && (p2?.connected ?? false);
+  }
+
+  getInputSource(playerId: PlayerId): InputSource | null {
+    const assignment = this.#assignments.get(playerId);
+
+    // Player 1 uses keyboard if no gamepad assigned or gamepad disconnected
+    if (playerId === 1 && this.#keyboardFallback) {
+      if (!assignment || !assignment.controller.connected) {
+        return this.#keyboardFallback;
+      }
+    }
+
+    return assignment?.controller ?? null;
+  }
+
+  enableKeyboardFallback(): void {
+    if (!this.#keyboardFallback) {
+      this.#keyboardFallback = new InputController();
+    }
+    this.#checkControllersReady();
+  }
+
+  disableKeyboardFallback(): void {
+    this.#keyboardFallback?.cleanup();
+    this.#keyboardFallback = null;
+    this.#checkControllersReady();
+  }
+
+  getConnectionStatus(): { player1: boolean; player2: boolean } {
+    return {
+      player1: this.getInputSource(1)?.connected ?? false,
+      player2: this.getInputSource(2)?.connected ?? false,
+    };
+  }
+
+  update(): void {
+    for (const assignment of this.#assignments.values()) {
+      if (assignment.controller.connected) {
+        assignment.controller.pollButtons();
+      }
+    }
+  }
+
+  cleanup(): void {
+    if (this.#pollInterval) {
+      clearInterval(this.#pollInterval);
+      this.#pollInterval = null;
+    }
+    this.#assignments.forEach((a) => a.controller.cleanup());
+    this.#keyboardFallback?.cleanup();
+    this.#assignments.clear();
+  }
+}

--- a/game/utils/input/GamepadManager.ts
+++ b/game/utils/input/GamepadManager.ts
@@ -1,6 +1,6 @@
-import { InputController } from '../InputController';
 import { GamepadController } from './GamepadController';
 import type { InputSource } from './InputSource';
+import { KeyboardController } from './KeyboardController';
 import { type ControllerProfile, LogitechProfile, PS4Profile, XboxProfile } from './profiles';
 
 export type PlayerId = 1 | 2;
@@ -15,7 +15,7 @@ export class GamepadManager extends EventTarget {
 
   #profiles: ControllerProfile[] = [LogitechProfile, XboxProfile, PS4Profile];
   #assignments = new Map<PlayerId, PlayerAssignment>();
-  #keyboardFallback: InputController | null = null;
+  #keyboardFallback: KeyboardController | null = null;
 
   private constructor() {
     super();
@@ -176,7 +176,7 @@ export class GamepadManager extends EventTarget {
 
   enableKeyboardFallback(): void {
     if (!this.#keyboardFallback) {
-      this.#keyboardFallback = new InputController();
+      this.#keyboardFallback = new KeyboardController();
     }
     this.#checkControllersReady();
   }

--- a/game/utils/input/GamepadManager.ts
+++ b/game/utils/input/GamepadManager.ts
@@ -74,7 +74,12 @@ export class GamepadManager extends EventTarget {
 
   #assignGamepad(gamepad: Gamepad): void {
     const profile = this.#detectProfile(gamepad);
-    const availableSlot = this.#getFirstAvailableSlot();
+    let availableSlot = this.#getFirstAvailableSlot();
+
+    // If no slot available, try to replace a disconnected controller
+    if (!availableSlot) {
+      availableSlot = this.#getDisconnectedSlot();
+    }
 
     if (availableSlot) {
       const controller = new GamepadController(gamepad.index, profile);
@@ -122,6 +127,22 @@ export class GamepadManager extends EventTarget {
     } else {
       if (!this.#assignments.has(1)) return 1;
       if (!this.#assignments.has(2)) return 2;
+    }
+    return null;
+  }
+
+  #getDisconnectedSlot(): PlayerId | null {
+    // Prefer slot 2 first if keyboard fallback is enabled
+    if (this.#keyboardFallback) {
+      const slot2 = this.#assignments.get(2);
+      if (slot2 && !slot2.controller.connected) return 2;
+      const slot1 = this.#assignments.get(1);
+      if (slot1 && !slot1.controller.connected) return 1;
+    } else {
+      const slot1 = this.#assignments.get(1);
+      if (slot1 && !slot1.controller.connected) return 1;
+      const slot2 = this.#assignments.get(2);
+      if (slot2 && !slot2.controller.connected) return 2;
     }
     return null;
   }

--- a/game/utils/input/InputSource.ts
+++ b/game/utils/input/InputSource.ts
@@ -1,0 +1,12 @@
+export interface InputVector {
+  x: number; // -1 to 1
+  z: number; // -1 to 1
+}
+
+export interface InputSource {
+  getMovement(): InputVector;
+  isButtonPressed(button: string): boolean;
+  onButtonUp(callback: (button: string) => void): void;
+  cleanup(): void;
+  readonly connected: boolean;
+}

--- a/game/utils/input/KeyboardController.ts
+++ b/game/utils/input/KeyboardController.ts
@@ -1,6 +1,6 @@
-import type { InputSource, InputVector } from './input/InputSource';
+import type { InputSource, InputVector } from './InputSource';
 
-export class InputController implements InputSource {
+export class KeyboardController implements InputSource {
   #buttonUpCallback: ((button: string) => void) | null = null;
   #boundKeyUpHandler: (event: KeyboardEvent) => void;
   #boundKeyDownHandler: (event: KeyboardEvent) => void;
@@ -11,7 +11,7 @@ export class InputController implements InputSource {
 
   constructor() {
     if (!window) {
-      throw new Error('"InputController" can only be instanciated in a browser environment.');
+      throw new Error('"KeyboardController" can only be instanciated in a browser environment.');
     }
 
     this.#boundKeyUpHandler = this.#handleKeyUp.bind(this);

--- a/game/utils/input/KeyboardController.ts
+++ b/game/utils/input/KeyboardController.ts
@@ -6,14 +6,16 @@ export class KeyboardController implements InputSource {
   #boundKeyDownHandler: (event: KeyboardEvent) => void;
 
   #keysPressed = new Set<string>();
+  #keySet?: 'player1' | 'player2';
 
   readonly connected = true;
 
-  constructor() {
+  constructor(keySet?: 'player1' | 'player2') {
     if (!window) {
       throw new Error('"KeyboardController" can only be instanciated in a browser environment.');
     }
 
+    this.#keySet = keySet;
     this.#boundKeyUpHandler = this.#handleKeyUp.bind(this);
     this.#boundKeyDownHandler = this.#handleKeyDown.bind(this);
 
@@ -33,24 +35,55 @@ export class KeyboardController implements InputSource {
     let x = 0;
     let z = 0;
 
-    if (
-      this.#keysPressed.has('ArrowLeft') ||
-      this.#keysPressed.has('KeyA') ||
-      this.#keysPressed.has('KeyQ')
-    ) {
-      x = -1;
-    } else if (this.#keysPressed.has('ArrowRight') || this.#keysPressed.has('KeyD')) {
-      x = 1;
-    }
+    // Player 1: WASD/ZQSD keys only
+    if (this.#keySet === 'player1') {
+      if (this.#keysPressed.has('KeyA') || this.#keysPressed.has('KeyQ')) {
+        x = -1;
+      } else if (this.#keysPressed.has('KeyD')) {
+        x = 1;
+      }
 
-    if (
-      this.#keysPressed.has('ArrowUp') ||
-      this.#keysPressed.has('KeyW') ||
-      this.#keysPressed.has('KeyZ')
-    ) {
-      z = -1;
-    } else if (this.#keysPressed.has('ArrowDown') || this.#keysPressed.has('KeyS')) {
-      z = 1;
+      if (this.#keysPressed.has('KeyW') || this.#keysPressed.has('KeyZ')) {
+        z = -1;
+      } else if (this.#keysPressed.has('KeyS')) {
+        z = 1;
+      }
+    }
+    // Player 2: Arrow keys only
+    else if (this.#keySet === 'player2') {
+      if (this.#keysPressed.has('ArrowLeft')) {
+        x = -1;
+      } else if (this.#keysPressed.has('ArrowRight')) {
+        x = 1;
+      }
+
+      if (this.#keysPressed.has('ArrowUp')) {
+        z = -1;
+      } else if (this.#keysPressed.has('ArrowDown')) {
+        z = 1;
+      }
+    }
+    // No keySet: all keys (backward compatibility)
+    else {
+      if (
+        this.#keysPressed.has('ArrowLeft') ||
+        this.#keysPressed.has('KeyA') ||
+        this.#keysPressed.has('KeyQ')
+      ) {
+        x = -1;
+      } else if (this.#keysPressed.has('ArrowRight') || this.#keysPressed.has('KeyD')) {
+        x = 1;
+      }
+
+      if (
+        this.#keysPressed.has('ArrowUp') ||
+        this.#keysPressed.has('KeyW') ||
+        this.#keysPressed.has('KeyZ')
+      ) {
+        z = -1;
+      } else if (this.#keysPressed.has('ArrowDown') || this.#keysPressed.has('KeyS')) {
+        z = 1;
+      }
     }
 
     return { x, z };

--- a/game/utils/input/index.ts
+++ b/game/utils/input/index.ts
@@ -1,4 +1,5 @@
 export { GamepadController } from './GamepadController';
 export { GamepadManager, type PlayerId } from './GamepadManager';
 export type { InputSource, InputVector } from './InputSource';
+export { KeyboardController } from './KeyboardController';
 export * from './profiles';

--- a/game/utils/input/index.ts
+++ b/game/utils/input/index.ts
@@ -1,0 +1,4 @@
+export { GamepadController } from './GamepadController';
+export { GamepadManager, type PlayerId } from './GamepadManager';
+export type { InputSource, InputVector } from './InputSource';
+export * from './profiles';

--- a/game/utils/input/profiles/ControllerProfile.ts
+++ b/game/utils/input/profiles/ControllerProfile.ts
@@ -1,0 +1,17 @@
+export interface ControllerProfile {
+  name: string;
+  matchPatterns: RegExp[];
+  leftStickX: number;
+  leftStickY: number;
+  buttons: {
+    a: number;
+    b: number;
+    x: number;
+    y: number;
+    start: number;
+    back: number;
+    leftBumper: number;
+    rightBumper: number;
+  };
+  deadzone: number;
+}

--- a/game/utils/input/profiles/LogitechProfile.ts
+++ b/game/utils/input/profiles/LogitechProfile.ts
@@ -1,0 +1,19 @@
+import type { ControllerProfile } from './ControllerProfile';
+
+export const LogitechProfile: ControllerProfile = {
+  name: 'Logitech',
+  matchPatterns: [/logitech/i, /046d/i],
+  leftStickX: 0,
+  leftStickY: 1,
+  buttons: {
+    a: 1,
+    b: 2,
+    x: 0,
+    y: 3,
+    start: 9,
+    back: 8,
+    leftBumper: 4,
+    rightBumper: 5,
+  },
+  deadzone: 0.15,
+};

--- a/game/utils/input/profiles/PS4Profile.ts
+++ b/game/utils/input/profiles/PS4Profile.ts
@@ -1,0 +1,19 @@
+import type { ControllerProfile } from './ControllerProfile';
+
+export const PS4Profile: ControllerProfile = {
+  name: 'PlayStation',
+  matchPatterns: [/playstation/i, /dualshock/i, /054c/i, /wireless controller/i],
+  leftStickX: 0,
+  leftStickY: 1,
+  buttons: {
+    a: 0, // Cross
+    b: 1, // Circle
+    x: 2, // Square
+    y: 3, // Triangle
+    start: 9, // Options
+    back: 8, // Share
+    leftBumper: 4, // L1
+    rightBumper: 5, // R1
+  },
+  deadzone: 0.15,
+};

--- a/game/utils/input/profiles/XboxProfile.ts
+++ b/game/utils/input/profiles/XboxProfile.ts
@@ -1,0 +1,19 @@
+import type { ControllerProfile } from './ControllerProfile';
+
+export const XboxProfile: ControllerProfile = {
+  name: 'Xbox',
+  matchPatterns: [/xbox/i, /xinput/i, /045e/i, /microsoft/i],
+  leftStickX: 0,
+  leftStickY: 1,
+  buttons: {
+    a: 0,
+    b: 1,
+    x: 2,
+    y: 3,
+    start: 9,
+    back: 8,
+    leftBumper: 4,
+    rightBumper: 5,
+  },
+  deadzone: 0.15,
+};

--- a/game/utils/input/profiles/index.ts
+++ b/game/utils/input/profiles/index.ts
@@ -1,0 +1,4 @@
+export type { ControllerProfile } from './ControllerProfile';
+export { LogitechProfile } from './LogitechProfile';
+export { PS4Profile } from './PS4Profile';
+export { XboxProfile } from './XboxProfile';

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -11,6 +11,12 @@ export default defineNuxtConfig({
     autoImport: false,
   },
 
+  runtimeConfig: {
+    public: {
+      keyboardFallbackEnabled: true,
+    },
+  },
+
   vite: {
     plugins: [glslPlugin()],
   },


### PR DESCRIPTION
## Changes

- Handle keyboard control with ZQSD keys for player 1.
- Handle keyboard control with arrow keys for player 2.
- Handle gamepads control for 2 players, which override keyboard controls.
- Declare gamepad profiles for dummy Logitech pads, Playstation 4, and XBox controllers.
- Add a temporary HUD for debugging purpose (will be removed when reassured that it works for a period of time).